### PR TITLE
Support the hast "comment" node type, and support header comments that contain <tags>

### DIFF
--- a/test/samples/comment-before-non-svg-root/input.svg
+++ b/test/samples/comment-before-non-svg-root/input.svg
@@ -1,0 +1,5 @@
+<!-- pre-root-element comment - ignored as the root element is not svg -->
+<g>
+	<!-- this comment will be loaded as a hast comment node -->
+</g>
+<!-- post-root-element comment - silently ignored -->

--- a/test/samples/comment-before-non-svg-root/output.json
+++ b/test/samples/comment-before-non-svg-root/output.json
@@ -8,7 +8,7 @@
 			"children": [
 				{
 					"type": "comment",
-					"value": " stuff goes here "
+					"value": " this comment will be loaded as a hast comment node "
 				}
 			]
 		}

--- a/test/samples/comment-before-svg-root/input.svg
+++ b/test/samples/comment-before-svg-root/input.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="yes"?>
+<!-- pre-root-element comment - will be added to svg metadata -->
+<svg xmlns="http://www.w3.org/2000/svg">
+	<!-- this comment will be loaded as a hast comment node -->
+	<path d='M0,0 L10,0 L10,10 L0,10Z'>
+		<!-- as will this one -->
+	</path>
+</svg>
+<!-- post-root-element comment - silently ignored -->

--- a/test/samples/comment-before-svg-root/output.json
+++ b/test/samples/comment-before-svg-root/output.json
@@ -1,0 +1,32 @@
+{
+	"type": "root",
+	"children": [
+		{
+			"type": "element",
+			"tagName": "svg",
+			"metadata": "<?xml version=\"1.0\" standalone=\"yes\"?>\n<!-- pre-root-element comment - will be added to svg metadata -->\n",
+			"properties": {
+				"xmlns": "http://www.w3.org/2000/svg"
+			},
+			"children": [
+				{
+					"type": "comment",
+					"value": " this comment will be loaded as a hast comment node "
+				},
+				{
+					"type": "element",
+					"tagName": "path",
+					"properties": {
+						"d": "M0,0 L10,0 L10,10 L0,10Z"
+					},
+					"children": [
+						{
+							"type": "comment",
+							"value": " as will this one "
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/test/samples/comment-containing-tags/input.svg
+++ b/test/samples/comment-containing-tags/input.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="yes"?>
+<!-- pre-root-element comment - will be added to <svg> metadata -->
+<svg xmlns="http://www.w3.org/2000/svg">
+	<!-- this comment will be loaded as a hast comment node -->
+	<path d='M0,0 L10,0 L10,10 L0,10Z'>
+		<!-- this comment contains a <tag> -->
+	</path>
+</svg>
+<!-- post-root-element comment - silently ignored -->

--- a/test/samples/comment-containing-tags/output.json
+++ b/test/samples/comment-containing-tags/output.json
@@ -1,0 +1,32 @@
+{
+	"type": "root",
+	"children": [
+		{
+			"type": "element",
+			"tagName": "svg",
+			"metadata": "<?xml version=\"1.0\" standalone=\"yes\"?>\n<!-- pre-root-element comment - will be added to <svg> metadata -->\n",
+			"properties": {
+				"xmlns": "http://www.w3.org/2000/svg"
+			},
+			"children": [
+				{
+					"type": "comment",
+					"value": " this comment will be loaded as a hast comment node "
+				},
+				{
+					"type": "element",
+					"tagName": "path",
+					"properties": {
+						"d": "M0,0 L10,0 L10,10 L0,10Z"
+					},
+					"children": [
+						{
+							"type": "comment",
+							"value": " this comment contains a <tag> "
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Hi

Thanks for this useful tool.  I'm submitting this PR for two reasons:

1. hast `comment` node-type support
1. A bug when parsing pre-root-tag comments that contain <tag>-style text

### Support the hast `comment` node-type
I noticed that comments were being stripped from SVGs - for a variety of reasons I needed to keep them, so I forked your repo and implemented the hast comment node type.

### Bug in parsing header/metadata comments that contain <tags>
If a comment in the header section contains a <tag>, the parser fails to parse the file.  e.g. this SVG would fail to parse due to the <some tag/> tag in the comment.  Tags are legal in HTML comments, and should not be escaped to &lt; / &gt;.

```xml
<?xml version="1.0" standalone="yes"?>
<!-- pre-root-element comment with <some tag/> in it -->
<svg xmlns="http://www.w3.org/2000/svg"></svg>
```

I've also written tests for this extra functionality, and updated the expected output from your original comment test.

Kind regards

Andy
