### PR TITLE
Extend the Error object with metadata

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,8 @@ export function parse(source) {
 
 		const snippet = `${beforeLine}${afterLine}\n${repeat(' ', beforeLine.length)}^`;
 
-		throw new Error(
-			`${message} (${line}:${column}). If this is valid SVG, it's probably a bug in svg-parser. Please raise an issue at https://github.com/Rich-Harris/svg-parser/issues – thanks!\n\n${snippet}`
-		);
+		const msg = `${message} (${line}:${column}). If this is valid SVG, it's probably a bug in svg-parser. Please raise an issue at https://github.com/Rich-Harris/svg-parser/issues – thanks!\n\n${snippet}`;
+		throw Object.assign(new Error(msg), { line, column, snippet, message });
 	}
 
 	function metadata() {


### PR DESCRIPTION
The primary reason you'd want this is to allow catching the svg-parser errors with metadata attached.
In my particular case I don't want my end users shown the message (I carefully catch and rethrow errors with messages meant for end users if they do something irrecoverable).

I want to tell them they did something wrong and let _me_ handle PRs/Issues if the svg-parser turns out to be at fault (highly unlikely).