### PR TITLE
Use const instead of let, 'stack' not reassigned.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ function repeat(str, i) {
 
 export function parse(source) {
 	let header = '';
-	let stack = [];
+	const stack = [];
 
 	let state = metadata;
 	let currentElement = null;


### PR DESCRIPTION
'stack' is never reassigned. Use 'const' instead.

If a variable is never reassigned, using the const declaration is better. const declaration tells readers, “this variable is never reassigned,” reducing cognitive load and improving maintainability.
From: https://eslint.org/docs/latest/rules/prefer-const